### PR TITLE
Wrong version for RSEM v1.3.3

### DIFF
--- a/rsem_perl_utils.pm
+++ b/rsem_perl_utils.pm
@@ -9,7 +9,7 @@ our @ISA = qw(Exporter);
 our @EXPORT = qw(runCommand);
 our @EXPORT_OK = qw(runCommand collectResults showVersionInfo getSAMTOOLS hasPolyA);
 
-my $version = "RSEM v1.3.1"; # Update version info here
+my $version = "RSEM v1.3.3"; # Update version info here
 my $samtools = "samtools-1.3"; # If update to another version of SAMtools, need to change this
 
 # command, {err_msg}


### PR DESCRIPTION
Hi,
I have created a PR to correct the RSEM version here `https://github.com/deweylab/RSEM/blob/master/rsem_perl_utils.pm#L12`.

Thanks,
Khushbu